### PR TITLE
Unreachable ctors and missing includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,9 @@ set(SOURCES
 # SSELegacy.cpp compiled separately to escape the effects of link-time optimization
 if(NOT MSVC)
 set_source_files_properties(${SOURCES} PROPERTIES COMPILE_FLAGS "-msse4.1 -msse4.2 -std=c++14")
+if(CUSTOM_FLAGS)
 string(REPLACE "-flto=thin" "" CUSTOM_FLAGS ${CMAKE_CXX_FLAGS})
+endif(CUSTOM_FLAGS)
 if (CMAKE_OSX_DEPLOYMENT_TARGET AND NOT CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
     set(CUSTOM_FLAGS "${CUSTOM_FLAGS} -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET} -O3 -msse3 -std=c++14")
 else()

--- a/include/zeus/CQuaternion.hpp
+++ b/include/zeus/CQuaternion.hpp
@@ -58,6 +58,35 @@ public:
 #endif
     }
 
+    operator atVec4f()
+    {
+        atVec4f ret;
+#if __SSE__
+        ret.mVec128 = mVec128;
+#else
+        ret.vec[0] = w;
+        ret.vec[1] = x;
+        ret.vec[2] = y;
+        ret.vec[3] = z;
+#endif
+        return ret;
+    }
+    operator atVec4f() const
+    {
+        atVec4f ret;
+#if __SSE__
+        ret.mVec128 = mVec128;
+#else
+        ret.vec[0] = w;
+        ret.vec[1] = x;
+        ret.vec[2] = y;
+        ret.vec[3] = z;
+#endif
+        return ret;
+    }
+
+#endif
+    
     CQuaternion(const CMatrix3f& mat)
     {
         float trace = mat[0][0] + mat[1][1] + mat[2][2];
@@ -97,35 +126,7 @@ public:
             }
         }
     }
-
-    operator atVec4f()
-    {
-        atVec4f ret;
-#if __SSE__
-        ret.mVec128 = mVec128;
-#else
-        ret.vec[0] = w;
-        ret.vec[1] = x;
-        ret.vec[2] = y;
-        ret.vec[3] = z;
-#endif
-        return ret;
-    }
-    operator atVec4f() const
-    {
-        atVec4f ret;
-#if __SSE__
-        ret.mVec128 = mVec128;
-#else
-        ret.vec[0] = w;
-        ret.vec[1] = x;
-        ret.vec[2] = y;
-        ret.vec[3] = z;
-#endif
-        return ret;
-    }
-
-#endif
+    
     CQuaternion(const CVector3f& vec) { fromVector3f(vec); }
     CQuaternion(const CVector4f& vec)
     {

--- a/include/zeus/CTransform.hpp
+++ b/include/zeus/CTransform.hpp
@@ -5,6 +5,8 @@
 #include "zeus/CMatrix3f.hpp"
 #include "zeus/CMatrix4f.hpp"
 #include "zeus/CVector3f.hpp"
+#include <stdint.h>
+#include <stdio.h>
 
 namespace zeus
 {

--- a/include/zeus/CVector3d.hpp
+++ b/include/zeus/CVector3d.hpp
@@ -145,8 +145,9 @@ public:
     inline CVector3d operator+(const CVector3d& rhs) const
     {
 #if __SSE__
-        return CVector3d({_mm_add_pd(mVec128[0], rhs.mVec128[0]),
-                          _mm_add_pd(mVec128[1], rhs.mVec128[1])});
+        const __m128d tmpVec128[2] = {_mm_add_pd(mVec128[0], rhs.mVec128[0]),
+                                      _mm_add_pd(mVec128[1], rhs.mVec128[1])};
+        return CVector3d(tmpVec128);
 #elif __GEKKO_PS__
         return CVector3d(__mm_gekko_add_pd(mVec128, rhs.mVec128));
 #else
@@ -156,8 +157,9 @@ public:
     inline CVector3d operator-(const CVector3d& rhs) const
     {
 #if __SSE__
-        return CVector3d({_mm_sub_pd(mVec128[0], rhs.mVec128[0]),
-                          _mm_sub_pd(mVec128[1], rhs.mVec128[1])});
+        const __m128d tmpVec128[2] = {_mm_add_pd(mVec128[0], rhs.mVec128[0]),
+                                      _mm_add_pd(mVec128[1], rhs.mVec128[1])};
+        return CVector3d(tmpVec128);
 #else
         return CVector3d(x - rhs.x, y - rhs.y, z - rhs.z);
 #endif
@@ -165,8 +167,9 @@ public:
     inline CVector3d operator*(const CVector3d& rhs) const
     {
 #if __SSE__
-        return CVector3d({_mm_mul_pd(mVec128[0], rhs.mVec128[0]),
-                          _mm_mul_pd(mVec128[1], rhs.mVec128[1])});
+        const __m128d tmpVec128[2] = {_mm_add_pd(mVec128[0], rhs.mVec128[0]),
+                                      _mm_add_pd(mVec128[1], rhs.mVec128[1])};
+        return CVector3d(tmpVec128);
 #else
         return CVector3d(x * rhs.x, y * rhs.y, z * rhs.z);
 #endif
@@ -174,8 +177,9 @@ public:
     inline CVector3d operator/(const CVector3d& rhs) const
     {
 #if __SSE__
-        return CVector3d({_mm_div_pd(mVec128[0], rhs.mVec128[0]),
-                          _mm_div_pd(mVec128[1], rhs.mVec128[1])});
+        const __m128d tmpVec128[2] = {_mm_add_pd(mVec128[0], rhs.mVec128[0]),
+                                      _mm_add_pd(mVec128[1], rhs.mVec128[1])};
+        return CVector3d(tmpVec128);
 #else
         return CVector3d(x / rhs.x, y / rhs.y, z / rhs.z);
 #endif

--- a/include/zeus/CVector3f.hpp
+++ b/include/zeus/CVector3f.hpp
@@ -71,8 +71,6 @@ public:
         return ret;
     }
 
-    CVector3f(const CVector3d& vec);
-
     void readBig(athena::io::IStreamReader& input)
     {
         x = input.readFloatBig();
@@ -88,6 +86,8 @@ public:
         return ret;
     }
 #endif
+
+    CVector3f(const CVector3d& vec);
 
     CVector3f(float xyz) { splat(xyz); }
     void assign(float x, float y, float z)


### PR DESCRIPTION
I couldn't compile zeus out-of-the-box on a rather clean ArchLinux install, so I attempted to fix it.
This PR moves 2 ctors out of preproc directives preventing access to them. It also fixes some missing includes and adds a check in CMakeLists to prevent it from trying to replace empty compiler flags.
I hope this is useful and not stupid :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/zeus/5)
<!-- Reviewable:end -->
