### PR TITLE
CColor: Use using where applicable

### DIFF
--- a/include/zeus/CColor.hpp
+++ b/include/zeus/CColor.hpp
@@ -25,16 +25,16 @@
 #endif
 
 namespace zeus {
-typedef uint8_t Comp8;
-typedef uint32_t Comp32;
+using Comp8 = uint8_t;
+using Comp32 = uint32_t;
 constexpr float OneOver255 = 1.f / 255.f;
 
-typedef union {
+union RGBA32 {
   struct {
     Comp8 r, g, b, a;
   };
   Comp32 rgba;
-} RGBA32;
+};
 
 class CVector4f;
 


### PR DESCRIPTION
We can also simplify RGBA32's declaration. This also allows the type to be forward declared.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/zeus/10)
<!-- Reviewable:end -->
