### PR TITLE
CFrustum: Use std::array where applicable

### DIFF
--- a/include/zeus/CFrustum.hpp
+++ b/include/zeus/CFrustum.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include "zeus/CPlane.hpp"
 
 namespace zeus {
@@ -9,7 +10,7 @@ class CProjection;
 class CSphere;
 
 class CFrustum {
-  CPlane planes[6];
+  std::array<CPlane, 6> planes;
   bool valid = false;
 
 public:


### PR DESCRIPTION
Makes the array stronger-typed. We can also use it to convert a few loops into algorithms using the exposed iterator member functions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/zeus/11)
<!-- Reviewable:end -->
