### PR TITLE
CVector2i: Make interface constexpr where applicable

### DIFF
--- a/include/zeus/CVector2i.hpp
+++ b/include/zeus/CVector2i.hpp
@@ -28,7 +28,7 @@ public:
 
   bool operator==(const CVector2i& other) const { return x == other.x && y == other.y; }
 
-  bool operator!=(const CVector2i& other) const { return x != other.x || y != other.y; }
+  bool operator!=(const CVector2i& other) const { return !operator==(other); }
 
   CVector2i operator*(int32_t val) const { return CVector2i(x * val, y * val); }
 };

--- a/include/zeus/CVector2i.hpp
+++ b/include/zeus/CVector2i.hpp
@@ -16,7 +16,7 @@ public:
 
   constexpr CVector2i(const CVector2f& vec) noexcept : x(int32_t(vec.x())), y(int32_t(vec.y())) {}
 
-  constexpr CVector2f toVec2f() const noexcept { return CVector2f(x, y); }
+  constexpr CVector2f toVec2f() const noexcept { return CVector2f(float(x), float(y)); }
 
   constexpr CVector2i operator+(const CVector2i& val) const noexcept { return CVector2i(x + val.x, y + val.y); }
   constexpr CVector2i operator-(const CVector2i& val) const noexcept { return CVector2i(x - val.x, y - val.y); }

--- a/include/zeus/CVector2i.hpp
+++ b/include/zeus/CVector2i.hpp
@@ -1,23 +1,20 @@
 #pragma once
 
+#include <cstdint>
 #include "zeus/CVector2f.hpp"
 
 namespace zeus {
 
 class CVector2i {
 public:
-  union {
-    struct {
-      int x, y;
-    };
-    int v[2];
-  };
+  int32_t x = 0;
+  int32_t y = 0;
 
-  constexpr CVector2i() : x(0), y(0) {}
+  constexpr CVector2i() = default;
 
-  constexpr CVector2i(int xin, int yin) : x(xin), y(yin) {}
+  constexpr CVector2i(int32_t xin, int32_t yin) : x(xin), y(yin) {}
 
-  CVector2i(const CVector2f& vec) : x(int(vec.x())), y(int(vec.y())) {}
+  CVector2i(const CVector2f& vec) : x(int32_t(vec.x())), y(int32_t(vec.y())) {}
 
   CVector2f toVec2f() const { return CVector2f(x, y); }
 
@@ -33,6 +30,6 @@ public:
 
   bool operator!=(const CVector2i& other) const { return x != other.x || y != other.y; }
 
-  CVector2i operator*(int val) const { return CVector2i(x * val, y * val); }
+  CVector2i operator*(int32_t val) const { return CVector2i(x * val, y * val); }
 };
 } // namespace zeus

--- a/include/zeus/CVector2i.hpp
+++ b/include/zeus/CVector2i.hpp
@@ -10,26 +10,22 @@ public:
   int32_t x = 0;
   int32_t y = 0;
 
-  constexpr CVector2i() = default;
+  constexpr CVector2i() noexcept = default;
 
-  constexpr CVector2i(int32_t xin, int32_t yin) : x(xin), y(yin) {}
+  constexpr CVector2i(int32_t xin, int32_t yin) noexcept : x(xin), y(yin) {}
 
-  CVector2i(const CVector2f& vec) : x(int32_t(vec.x())), y(int32_t(vec.y())) {}
+  constexpr CVector2i(const CVector2f& vec) noexcept : x(int32_t(vec.x())), y(int32_t(vec.y())) {}
 
-  CVector2f toVec2f() const { return CVector2f(x, y); }
+  constexpr CVector2f toVec2f() const noexcept { return CVector2f(x, y); }
 
-  CVector2i operator+(const CVector2i& val) const { return CVector2i(x + val.x, y + val.y); }
+  constexpr CVector2i operator+(const CVector2i& val) const noexcept { return CVector2i(x + val.x, y + val.y); }
+  constexpr CVector2i operator-(const CVector2i& val) const noexcept { return CVector2i(x - val.x, y - val.y); }
+  constexpr CVector2i operator*(const CVector2i& val) const noexcept { return CVector2i(x * val.x, y * val.y); }
+  constexpr CVector2i operator/(const CVector2i& val) const noexcept { return CVector2i(x / val.x, y / val.y); }
 
-  CVector2i operator-(const CVector2i& val) const { return CVector2i(x - val.x, y - val.y); }
+  constexpr bool operator==(const CVector2i& other) const noexcept { return x == other.x && y == other.y; }
+  constexpr bool operator!=(const CVector2i& other) const noexcept { return !operator==(other); }
 
-  CVector2i operator*(const CVector2i& val) const { return CVector2i(x * val.x, y * val.y); }
-
-  CVector2i operator/(const CVector2i& val) const { return CVector2i(x / val.x, y / val.y); }
-
-  bool operator==(const CVector2i& other) const { return x == other.x && y == other.y; }
-
-  bool operator!=(const CVector2i& other) const { return !operator==(other); }
-
-  CVector2i operator*(int32_t val) const { return CVector2i(x * val, y * val); }
+  constexpr CVector2i operator*(int32_t val) const noexcept { return CVector2i(x * val, y * val); }
 };
 } // namespace zeus

--- a/include/zeus/CVector2i.hpp
+++ b/include/zeus/CVector2i.hpp
@@ -28,4 +28,6 @@ public:
 
   constexpr CVector2i operator*(int32_t val) const noexcept { return CVector2i(x * val, y * val); }
 };
+static_assert(sizeof(CVector2i) == sizeof(int32_t) * 2);
+
 } // namespace zeus


### PR DESCRIPTION
Given these member functions only manipulate two integral values, we can make the interface constexpr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/zeus/14)
<!-- Reviewable:end -->
