### PR TITLE
Global: Mark hash_combine_impl() as noexcept

### DIFF
--- a/include/zeus/Global.hpp
+++ b/include/zeus/Global.hpp
@@ -16,8 +16,8 @@ using simd_doubles = athena::simd_doubles;
 #endif
 
 template <typename SizeT>
-constexpr void hash_combine_impl(SizeT& seed, SizeT value) {
-  seed ^= value + 0x9e3779b9 + (seed<<6) + (seed>>2);
+constexpr void hash_combine_impl(SizeT& seed, SizeT value) noexcept {
+  seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 } // namespace zeus
 


### PR DESCRIPTION
This is used with hashes that are declared noexcept, so this should also be noexcept.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/zeus/15)
<!-- Reviewable:end -->
