### PR TITLE
Global: Remove unused rotr/rotl functions

### DIFF
--- a/include/zeus/Global.hpp
+++ b/include/zeus/Global.hpp
@@ -20,6 +20,3 @@ constexpr void hash_combine_impl(SizeT& seed, SizeT value) {
   seed ^= value + 0x9e3779b9 + (seed<<6) + (seed>>2);
 }
 } // namespace zeus
-
-constexpr int rotr(int x, int n) { return ((x >> n) | (x << (32 - n))); }
-constexpr int rotl(int x, int n) { return ((x << n) | (x >> (32 - n))); }


### PR DESCRIPTION
These don't appear to be used by anything, so they can be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/zeus/16)
<!-- Reviewable:end -->
