### PR TITLE
CVector2i: Make CVector2f-related constructor non-constexpr

### DIFF
--- a/include/zeus/CVector2i.hpp
+++ b/include/zeus/CVector2i.hpp
@@ -14,7 +14,7 @@ public:
 
   constexpr CVector2i(int32_t xin, int32_t yin) noexcept : x(xin), y(yin) {}
 
-  constexpr CVector2i(const CVector2f& vec) noexcept : x(int32_t(vec.x())), y(int32_t(vec.y())) {}
+  CVector2i(const CVector2f& vec) noexcept : x(int32_t(vec.x())), y(int32_t(vec.y())) {}
 
   constexpr CVector2f toVec2f() const noexcept { return CVector2f(float(x), float(y)); }
 


### PR DESCRIPTION
These make use of SIMD accessors, which aren't constexpr. This was accidentally introduced by me in https://github.com/AxioDL/zeus/commit/056515b2d3740d2397a1fa9a624dab9ef86b70aa (my bad!)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/zeus/19)
<!-- Reviewable:end -->
